### PR TITLE
Add morning planning session with start/status subcommands

### DIFF
--- a/cmd/day-planner/main.go
+++ b/cmd/day-planner/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/EwanGreer/day-planner/internal/config"
+	"github.com/EwanGreer/day-planner/internal/core"
 	"github.com/EwanGreer/day-planner/internal/integrations/jira"
 	"github.com/EwanGreer/day-planner/internal/integrations/taskwarrior"
 	"github.com/EwanGreer/day-planner/internal/nudge"
@@ -59,54 +60,51 @@ func main() {
 		}
 	}()
 
-	if wc.IsBlocked(time.Now()) {
-		if err := presenter.ShowMessage(wc.StatusMessage(time.Now())); err != nil {
+	if len(os.Args) < 2 {
+		if err := presenter.ShowMessage("Usage: day-planner <start|status>"); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
 		}
-	}
-
-	tw := taskwarrior.New()
-
-	if err := presenter.ShowMessage(fmt.Sprintf("Data dir: %s", dataDir)); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := presenter.ShowMessage(fmt.Sprintf("Store opened at %s", dbPath)); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	switch os.Args[1] {
+	case "start":
+		runStart(store, presenter, cfg)
+	case "status":
+		runStatus(wc, presenter)
+	default:
+		if err := presenter.ShowMessage(fmt.Sprintf("Unknown command: %s", os.Args[1])); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
 		os.Exit(1)
 	}
+}
 
-	if err := presenter.ShowMessage("Day Planner starting..."); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+// runStart wires together the task providers and planning service, then
+// executes the morning planning session for today.
+func runStart(store core.Store, presenter core.PlanPresenter, cfg *core.Config) {
+	var providers []core.TaskProvider
 
 	if cfg.Taskwarrior.Enabled {
-		if !tw.IsAvailable() {
-			if err := presenter.ShowMessage("Taskwarrior not found in PATH -- skipping"); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				os.Exit(1)
-			}
-		} else {
-			tasks, err := tw.FetchTasks()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "taskwarrior error: %v\n", err)
-				os.Exit(1)
-			}
-			if err := presenter.ShowTaskList(tasks); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				os.Exit(1)
-			}
-		}
+		providers = append(providers, taskwarrior.New())
 	}
 
 	if cfg.Jira.Enabled {
-		jiraAdapter := jira.New(cfg.Jira)
-		// jiraAdapter will be wired into the planning service in a subsequent issue.
-		_ = jiraAdapter
+		providers = append(providers, jira.New(cfg.Jira))
 	}
 
-	_ = store // store will be passed to services in subsequent issues
+	svc := core.NewPlanningService(store, providers, presenter)
+	if _, err := svc.StartMorning(time.Now()); err != nil {
+		fmt.Fprintf(os.Stderr, "start morning: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runStatus prints the current focus-window status message.
+func runStatus(wc *nudge.WindowChecker, presenter core.PlanPresenter) {
+	msg := wc.StatusMessage(time.Now())
+	if err := presenter.ShowMessage(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -1,0 +1,31 @@
+package core
+
+// TaskProvider is the interface integration adapters must satisfy to provide tasks.
+// Defined here so core can depend on it without importing integration packages.
+//
+// Note: the name TaskSource is already taken as a string type in domain.go
+// (it identifies the origin of a task, e.g. "taskwarrior"). TaskProvider is
+// used here to avoid a redeclaration conflict.
+type TaskProvider interface {
+	// Name returns the human-readable name of the provider.
+	Name() string
+	// FetchTasks retrieves tasks from the external source.
+	FetchTasks() ([]Task, error)
+	// IsAvailable reports whether the provider is configured and reachable.
+	IsAvailable() bool
+}
+
+// PlanPresenter is the subset of view.Presenter used by PlanningService.
+// Defined here so core can depend on it without importing the view package.
+type PlanPresenter interface {
+	// ShowTaskList displays the prioritised list of tasks.
+	ShowTaskList(tasks []Task) error
+	// PromptCommitments asks the user to select tasks to commit to.
+	PromptCommitments(tasks []Task) ([]Task, error)
+	// ShowPlanConfirmation displays the confirmed plan and current streak.
+	ShowPlanConfirmation(plan *DayPlan, streak *Streak) error
+	// ShowMessage displays a plain informational message.
+	ShowMessage(msg string) error
+	// ShowError displays an error to the user.
+	ShowError(err error)
+}

--- a/internal/core/planning.go
+++ b/internal/core/planning.go
@@ -1,0 +1,87 @@
+package core
+
+import "time"
+
+// PlanningService orchestrates the morning planning session.
+type PlanningService struct {
+	store     Store
+	providers []TaskProvider
+	presenter PlanPresenter
+}
+
+// NewPlanningService creates a PlanningService wired with the given store,
+// task providers, and presenter.
+func NewPlanningService(store Store, providers []TaskProvider, presenter PlanPresenter) *PlanningService {
+	return &PlanningService{
+		store:     store,
+		providers: providers,
+		presenter: presenter,
+	}
+}
+
+// StartMorning runs the morning planning session for the given date.
+// It returns the saved DayPlan on success. If a plan already exists for
+// today it reports the fact and returns the existing plan without error.
+func (s *PlanningService) StartMorning(date time.Time) (*DayPlan, error) {
+	// 1. Check for an existing plan — bail out early if one already exists.
+	existing, err := s.store.LoadDayPlan(date)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		if err := s.presenter.ShowMessage("A plan for today already exists."); err != nil {
+			return nil, err
+		}
+		return existing, nil
+	}
+
+	// 2. Fetch tasks from all available providers.
+	var allTasks []Task
+	for _, p := range s.providers {
+		if !p.IsAvailable() {
+			continue
+		}
+		tasks, err := p.FetchTasks()
+		if err != nil {
+			s.presenter.ShowError(err)
+			continue
+		}
+		allTasks = append(allTasks, tasks...)
+	}
+
+	// 3. Present the task list.
+	if err := s.presenter.ShowTaskList(allTasks); err != nil {
+		return nil, err
+	}
+
+	// 4. Prompt the user to select their commitments.
+	committed, err := s.presenter.PromptCommitments(allTasks)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. Build and persist the day plan.
+	plan := DayPlan{
+		Date:      date,
+		Tasks:     committed,
+		Goals:     []string{},
+		CreatedAt: time.Now(),
+	}
+	if err := s.store.SaveDayPlan(&plan); err != nil {
+		return nil, err
+	}
+
+	// 6. Load the current streak; a missing streak is treated as zero.
+	streak, err := s.store.LoadStreak()
+	if err != nil {
+		streak = &Streak{}
+	}
+
+	// 7. Confirm the plan to the user.
+	if err := s.presenter.ShowPlanConfirmation(&plan, streak); err != nil {
+		return nil, err
+	}
+
+	// 8. Return the saved plan.
+	return &plan, nil
+}

--- a/internal/core/planning_test.go
+++ b/internal/core/planning_test.go
@@ -1,0 +1,277 @@
+package core_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/EwanGreer/day-planner/internal/core"
+)
+
+// fakeStore is an in-memory implementation of core.Store for testing.
+type fakeStore struct {
+	plans       map[string]*core.DayPlan // keyed by date "2006-01-02"
+	streak      *core.Streak
+	streakErr   error
+	savePlanErr error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{plans: make(map[string]*core.DayPlan)}
+}
+
+func (s *fakeStore) SaveDayPlan(plan *core.DayPlan) error {
+	if s.savePlanErr != nil {
+		return s.savePlanErr
+	}
+	key := plan.Date.Format("2006-01-02")
+	s.plans[key] = plan
+	return nil
+}
+
+func (s *fakeStore) LoadDayPlan(date time.Time) (*core.DayPlan, error) {
+	key := date.Format("2006-01-02")
+	return s.plans[key], nil
+}
+
+func (s *fakeStore) SaveCompletion(record core.CompletionRecord) error   { return nil }
+func (s *fakeStore) LoadCompletions(_ time.Time) ([]core.CompletionRecord, error) {
+	return nil, nil
+}
+func (s *fakeStore) SaveStreak(_ core.Streak) error { return nil }
+func (s *fakeStore) LoadStreak() (*core.Streak, error) {
+	return s.streak, s.streakErr
+}
+func (s *fakeStore) SaveReflection(_ core.Reflection) error { return nil }
+func (s *fakeStore) LoadReflections(_ time.Time) ([]core.Reflection, error) {
+	return nil, nil
+}
+func (s *fakeStore) SaveNudgeWindow(_ core.NudgeWindow) error { return nil }
+func (s *fakeStore) LoadNudgeWindows() ([]core.NudgeWindow, error) {
+	return nil, nil
+}
+func (s *fakeStore) Close() error { return nil }
+
+// fakeProvider is a configurable core.TaskProvider.
+type fakeProvider struct {
+	name      string
+	available bool
+	tasks     []core.Task
+	err       error
+}
+
+func (p *fakeProvider) Name() string               { return p.name }
+func (p *fakeProvider) IsAvailable() bool          { return p.available }
+func (p *fakeProvider) FetchTasks() ([]core.Task, error) { return p.tasks, p.err }
+
+// fakePresenter records all presenter calls and returns configurable responses.
+type fakePresenter struct {
+	taskListShown    []core.Task
+	commitmentTasks  []core.Task
+	planConfirmed    *core.DayPlan
+	streakShown      *core.Streak
+	messages         []string
+	errors           []error
+
+	commitmentResult []core.Task
+	commitmentErr    error
+}
+
+func (p *fakePresenter) ShowTaskList(tasks []core.Task) error {
+	p.taskListShown = append(p.taskListShown, tasks...)
+	return nil
+}
+
+func (p *fakePresenter) PromptCommitments(tasks []core.Task) ([]core.Task, error) {
+	p.commitmentTasks = append(p.commitmentTasks, tasks...)
+	if p.commitmentResult != nil {
+		return p.commitmentResult, p.commitmentErr
+	}
+	return tasks, p.commitmentErr
+}
+
+func (p *fakePresenter) ShowPlanConfirmation(plan *core.DayPlan, streak *core.Streak) error {
+	p.planConfirmed = plan
+	p.streakShown = streak
+	return nil
+}
+
+func (p *fakePresenter) ShowMessage(msg string) error {
+	p.messages = append(p.messages, msg)
+	return nil
+}
+
+func (p *fakePresenter) ShowError(err error) {
+	p.errors = append(p.errors, err)
+}
+
+// TestStartMorning_HappyPath verifies the full happy-path: tasks fetched from
+// a provider, user selects 2 commitments, plan saved, confirmation shown.
+func TestStartMorning_HappyPath(t *testing.T) {
+	today := time.Now().Truncate(24 * time.Hour)
+
+	tasks := []core.Task{
+		{ID: "1", Title: "Task A", Source: core.TaskSourceTaskwarrior},
+		{ID: "2", Title: "Task B", Source: core.TaskSourceTaskwarrior},
+		{ID: "3", Title: "Task C", Source: core.TaskSourceTaskwarrior},
+	}
+
+	provider := &fakeProvider{name: "taskwarrior", available: true, tasks: tasks}
+	store := newFakeStore()
+	store.streak = &core.Streak{Current: 3, Longest: 5}
+
+	presenter := &fakePresenter{
+		commitmentResult: tasks[:2], // user picks first two
+	}
+
+	svc := core.NewPlanningService(store, []core.TaskProvider{provider}, presenter)
+	plan, err := svc.StartMorning(today)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if len(plan.Tasks) != 2 {
+		t.Errorf("expected 2 committed tasks, got %d", len(plan.Tasks))
+	}
+	if presenter.planConfirmed == nil {
+		t.Error("expected ShowPlanConfirmation to be called")
+	}
+	if presenter.streakShown == nil || presenter.streakShown.Current != 3 {
+		t.Errorf("expected streak current=3, got %+v", presenter.streakShown)
+	}
+	// plan should be persisted in the store
+	saved, _ := store.LoadDayPlan(today)
+	if saved == nil {
+		t.Error("expected plan to be saved in store")
+	}
+}
+
+// TestStartMorning_ExistingPlan verifies that when a plan already exists for
+// today, the service shows a message and returns the existing plan without
+// saving a new one.
+func TestStartMorning_ExistingPlan(t *testing.T) {
+	today := time.Now().Truncate(24 * time.Hour)
+	existing := &core.DayPlan{
+		Date:  today,
+		Tasks: []core.Task{{ID: "x", Title: "Existing Task"}},
+	}
+
+	store := newFakeStore()
+	store.plans[today.Format("2006-01-02")] = existing
+
+	presenter := &fakePresenter{}
+	provider := &fakeProvider{name: "tw", available: true, tasks: []core.Task{}}
+
+	svc := core.NewPlanningService(store, []core.TaskProvider{provider}, presenter)
+	plan, err := svc.StartMorning(today)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan != existing {
+		t.Error("expected the existing plan to be returned")
+	}
+	if len(presenter.messages) == 0 {
+		t.Error("expected an 'already exists' message to be shown")
+	}
+	// Confirm that no new plan was committed via PromptCommitments.
+	if len(presenter.commitmentTasks) != 0 {
+		t.Error("PromptCommitments should not have been called")
+	}
+}
+
+// TestStartMorning_NoTasks verifies that when all providers return no tasks,
+// the task list is still shown (empty), the user is still prompted, and a plan
+// with zero committed tasks is saved.
+func TestStartMorning_NoTasks(t *testing.T) {
+	today := time.Now().Truncate(24 * time.Hour)
+
+	provider := &fakeProvider{name: "tw", available: true, tasks: nil}
+	store := newFakeStore()
+	presenter := &fakePresenter{
+		commitmentResult: []core.Task{}, // user commits to nothing
+	}
+
+	svc := core.NewPlanningService(store, []core.TaskProvider{provider}, presenter)
+	plan, err := svc.StartMorning(today)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if len(plan.Tasks) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(plan.Tasks))
+	}
+	if presenter.planConfirmed == nil {
+		t.Error("expected ShowPlanConfirmation to be called")
+	}
+}
+
+// TestStartMorning_SourceError verifies that when one provider errors, the
+// error is shown via the presenter but the session continues with tasks from
+// other providers.
+func TestStartMorning_SourceError(t *testing.T) {
+	today := time.Now().Truncate(24 * time.Hour)
+
+	goodTasks := []core.Task{
+		{ID: "g1", Title: "Good Task", Source: core.TaskSourceTaskwarrior},
+	}
+	badProvider := &fakeProvider{
+		name:      "broken",
+		available: true,
+		err:       errors.New("connection refused"),
+	}
+	goodProvider := &fakeProvider{
+		name:      "taskwarrior",
+		available: true,
+		tasks:     goodTasks,
+	}
+
+	store := newFakeStore()
+	presenter := &fakePresenter{}
+
+	svc := core.NewPlanningService(store, []core.TaskProvider{badProvider, goodProvider}, presenter)
+	plan, err := svc.StartMorning(today)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(presenter.errors) == 0 {
+		t.Error("expected the provider error to be shown via ShowError")
+	}
+	if len(presenter.taskListShown) != 1 {
+		t.Errorf("expected 1 task from the good provider, got %d", len(presenter.taskListShown))
+	}
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+}
+
+// TestStartMorning_SaveError verifies that a store.SaveDayPlan error is
+// propagated back to the caller.
+func TestStartMorning_SaveError(t *testing.T) {
+	today := time.Now().Truncate(24 * time.Hour)
+
+	store := newFakeStore()
+	store.savePlanErr = errors.New("disk full")
+
+	presenter := &fakePresenter{}
+	provider := &fakeProvider{name: "tw", available: true, tasks: []core.Task{
+		{ID: "1", Title: "Task A"},
+	}}
+
+	svc := core.NewPlanningService(store, []core.TaskProvider{provider}, presenter)
+	_, err := svc.StartMorning(today)
+
+	if err == nil {
+		t.Fatal("expected an error from SaveDayPlan, got nil")
+	}
+	if !errors.Is(err, store.savePlanErr) {
+		t.Errorf("expected savePlanErr, got %v", err)
+	}
+}

--- a/internal/view/tui/tui.go
+++ b/internal/view/tui/tui.go
@@ -1,8 +1,11 @@
 package tui
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/EwanGreer/day-planner/internal/core"
 	"github.com/EwanGreer/day-planner/internal/view"
@@ -29,19 +32,58 @@ func (t *TUI) ShowTaskList(tasks []core.Task) error {
 	return nil
 }
 
-// PromptCommitments prints tasks and returns the first min(3, len(tasks)) as a stub.
-// A real interactive prompt will be added in issue #5.
+// PromptCommitments presents the task list and reads the user's selection from
+// stdin. The user enters a comma-separated list of 1-based indices. Exactly
+// 2 or 3 tasks must be selected; invalid input is rejected with a retry.
 func (t *TUI) PromptCommitments(tasks []core.Task) ([]core.Task, error) {
-	fmt.Println("Select your commitments for today:")
+	fmt.Println("\nSelect 2-3 tasks to commit to today (e.g. 1,3):")
 	for i, task := range tasks {
-		fmt.Printf("  %d. [%s] %s (priority: %d)\n",
-			i+1, task.Status, task.Title, task.Priority)
+		fmt.Printf("  [%d] %-50s urgency: %.1f  (%s)\n",
+			i+1, task.Title, task.Urgency, task.Source)
 	}
-	limit := 3
-	if len(tasks) < limit {
-		limit = len(tasks)
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("\nYour selection: ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("read input: %w", err)
+		}
+		selected, err := parseSelection(strings.TrimSpace(line), len(tasks))
+		if err != nil {
+			fmt.Printf("Invalid selection: %v. Please try again.\n", err)
+			continue
+		}
+		if len(selected) < 2 || len(selected) > 3 {
+			fmt.Println("Please select between 2 and 3 tasks.")
+			continue
+		}
+		result := make([]core.Task, len(selected))
+		for i, idx := range selected {
+			result[i] = tasks[idx-1]
+		}
+		return result, nil
 	}
-	return tasks[:limit], nil
+}
+
+// parseSelection parses a comma-separated list of 1-based indices, returning
+// an error if any index is out of range or duplicated.
+func parseSelection(s string, max int) ([]int, error) {
+	parts := strings.Split(s, ",")
+	seen := map[int]bool{}
+	var indices []int
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 1 || n > max {
+			return nil, fmt.Errorf("invalid index %q (valid: 1-%d)", p, max)
+		}
+		if seen[n] {
+			return nil, fmt.Errorf("duplicate index %d", n)
+		}
+		seen[n] = true
+		indices = append(indices, n)
+	}
+	return indices, nil
 }
 
 // ShowPlanConfirmation prints the confirmed day plan and streak info.


### PR DESCRIPTION
## Summary

- New `core.PlanningService` orchestrates the morning ritual: fetch tasks from providers, prompt commitments, save plan, show streak
- `TaskProvider` and `PlanPresenter` interfaces in `internal/core` keep the domain free of view/integration imports
- TUI `PromptCommitments` now reads real stdin input; enforces 2-3 task selection with retry on invalid input
- `day-planner start` runs the morning session; `day-planner status` shows focus window status
- Jira adapter wired into providers when `cfg.Jira.Enabled`
- Existing plan for today detected and reported without re-prompting
- Provider errors shown via presenter; session continues with remaining providers
- 5 unit tests using fake store and presenter

[closes #5]

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (5 planning tests green)
- [ ] CI passes on the PR branch
- [ ] `./day-planner start` prompts for task selection
- [ ] `./day-planner status` shows focus window status